### PR TITLE
Prevent gulp from stopping because of errors

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -168,3 +168,8 @@ gulp.task 'default', defaultTasks , ->
   http.createServer ecstatic root : "#{__dirname}/playground"
     .listen(8080)
   gutil.log gutil.colors.blue 'HTTP server ready localhost:8080'
+
+
+process.on 'uncaughtException', (e)->
+  gutil.log gutil.colors.red "An error has occured: #{e.name}"
+  console.error e


### PR DESCRIPTION
#### What does it do?

Adds an uncaughtException handler to gulp that prevents the process from exiting due to compile errors.
#### Where should the reviewer start?

`gulpfile.coffee`
#### How should it be manually tested?

Start the watch task with `gulp`, add some broken CoffeeScript to one of the watched files, watch the build process keep on going.
#### Any background context you want to provide?

Having to restart the gulp build every time a file gets saved with invalid / breaking CoffeeScript is annoying, @sinan had mentioned that this would be a "nice to have" -- and after today's nth gulp restart I decided to add it :)

I talked with some of the Gulp devs in IRC, and they said that this type of error handling for watch tasks will be handled in a future release
