### PR TITLE
playground doesnt have a kd.js because of pipe order

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -86,8 +86,8 @@ gulp.task 'coffee', ->
       .pipe gulpBuffer()
       .pipe pistachioCompiler()
       .pipe gulpif useUglify, uglify()
-      .pipe gulp.dest "playground/js"
       .pipe rename "kd.#{version}js"
+      .pipe gulp.dest "playground/js"
       .pipe gulp.dest "#{buildDir}/js"
 
     stream.pipe livereload()  if useLiveReload


### PR DESCRIPTION
it was creating a `playground/js/src/entry.coffee` with compiled javascript which is wrong.
