### PR TITLE
Added basic html template element view

### DIFF
--- a/src/core/templateview.coffee
+++ b/src/core/templateview.coffee
@@ -22,7 +22,7 @@ module.exports   = class KDTemplateView extends KDCustomHTMLView
     stylesEl           = document.createElement 'style'
     stylesEl.innerHTML = styles
 
-    window.markupEl    = parser.parseFromString markup, 'text/html'
+    markupEl    = parser.parseFromString markup, 'text/html'
 
     content.appendChild stylesEl
 


### PR DESCRIPTION
Usage example

```

buttonTemplate = new KDTemplateView
  markup : """
    <figure class='icon'></figure>
    <span><content></content></span>
  """
  styles : """

    :host {
      border-radius : 4px;
      color         : #fff;
      height        : 34px;
      line-height   : 34px;
      border        : none;
      shadow        : none;
      outline       : none;
      padding       : 0 9px 0 0
    }

    :host(.red)   { background : red }
    :host(.green) { background : green }

    .icon {
      display    : block;
      float      : left;
      width      : 16px;
      height     : 16px;
      margin     : 9px;
      background : yellow
    }

  """

button = new KDCustomHTMLView
  partial : 'hey i am a button'
  tagName : 'button'
  cssClass: 'red'

buttonTemplate.applyTo button

```
