### PR TITLE
Fix KDListItemView::getItemDataId behavior

### DIFF
--- a/src/components/list/listitemview.coffee
+++ b/src/components/list/listitemview.coffee
@@ -48,7 +48,9 @@ module.exports = class KDListItemView extends KDView
     @unsetClass "selected"
 
   getItemDataId: ->
-    id = if @getData().getId?() then @getData().getId()
-    else if @getData().id?      then @getData().id
-    else if @getData()._id?     then @getData()._id
+    data = @getData()
+
+    id = if data.getId?() then data.getId()
+    else if data.id?      then data.id
+    else if data._id?     then data._id
 


### PR DESCRIPTION
The problem was it was when there is an id of `0` it was trying to do

``` js
undefined || 0 || undefined // returns 'undefined'
```

result of this those items with the id of `0` would't to be added to `KDListViewController::itemsIndexed`.

This MR fixes that behavior.
