### PR TITLE
ListViewController: extract index decision to its own method

### DIFF
--- a/src/components/list/listviewcontroller.coffee
+++ b/src/components/list/listviewcontroller.coffee
@@ -113,6 +113,15 @@ module.exports = class KDListViewController extends KDViewController
   HELPERS
   ###
 
+  # get the index depending on the
+  # conditions. e.g `options.lastToFirst`
+  # This method can be overriden by subclasses
+  # to change the item order and get necessary index.
+  getIndex: (index) ->
+    return if @getOptions().lastToFirst
+    then @getItemCount() - index - 1
+    else index
+
   itemForId: (id) -> @itemsIndexed[id]
 
   getItemsOrdered: -> @itemsOrdered
@@ -180,7 +189,7 @@ module.exports = class KDListViewController extends KDViewController
   unregisterItem: (itemInstance, index) ->
 
     @emit 'UnregisteringItem', itemInstance, index
-    actualIndex = if @getOptions().lastToFirst then @getItemCount() - index - 1 else index
+    actualIndex = @getIndex index
 
     @getListItems().splice actualIndex, 1
     if itemInstance.getData()?

--- a/test/components/list/listviewcontroller.test.coffee
+++ b/test/components/list/listviewcontroller.test.coffee
@@ -144,6 +144,33 @@ describe 'KDListViewController', ->
 
         assert viewController.emit.calledWith 'AllItemsAddedToList'
 
+  describe 'getIndex', ->
+
+    realItemCountFn = KDListViewController::getItemCount
+
+    before -> KDListViewController::getItemCount = -> 10
+    after  -> KDListViewController::getItemCount = realItemCountFn
+
+    context 'when it is last to first', ->
+
+      it 'returns from bottom', ->
+        listViewStub = sinon.createStubInstance KDListView
+        viewController = new KDListViewController { view: listViewStub, lastToFirst: yes }
+
+        expected = viewController.getIndex 2
+
+        assert.equal expected, 7
+
+    context 'when it is not last to first', ->
+
+      it 'returns from top', ->
+        listViewStub = sinon.createStubInstance KDListView
+        viewController = new KDListViewController { view: listViewStub, lastToFirst: no }
+
+        expected = viewController.getIndex 2
+
+        assert.equal expected, 2
+
 
   describe 'putNoItemView', ->
 


### PR DESCRIPTION
This PR introduces a change to `KDListViewController` with extracting `the decision of index` depending on `lastToFirst` option to its own method. This gives us some advantages:
- It can be overriden by subclasses so that those can have their own mechanism.
- Remove hard dependency of `lastToFirst`.
