### PR TITLE
autocomplete: clear active item after selection

### DIFF
--- a/src/components/autocomplete/autocompletecontroller.coffee
+++ b/src/components/autocomplete/autocompletecontroller.coffee
@@ -82,7 +82,6 @@ module.exports = class KDAutoCompleteController extends KDViewController
           event.stopPropagation()
           event.preventDefault()
           return no
-        else
       when 40 #downarrow
         if @dropdown.getView().$().is(":visible")
           @dropdown.getListView().goDown()
@@ -190,7 +189,9 @@ module.exports = class KDAutoCompleteController extends KDViewController
     inputView = @getView()
     # log @getOptions().selectedItemsLimit, @selectedItemCounter
     if @getOptions().selectedItemsLimit is null or @getOptions().selectedItemsLimit > @selectedItemCounter
-      activeItem = @dropdown.getListView().getActiveItem()
+      listView = @dropdown.getListView()
+      activeItem = listView.getActiveItem()
+      listView.setActiveItem null
       if activeItem.item
         @appendAutoCompletedItem()
       @addItemToSubmitQueue activeItem.item

--- a/src/components/autocomplete/autocompletelist.coffee
+++ b/src/components/autocomplete/autocompletelist.coffee
@@ -47,3 +47,6 @@ module.exports = class KDAutoCompleteListView extends KDListView
         active.index = i
         break
     active
+
+  setActiveItem: (target) ->
+    item.active = item is target  for item in @items


### PR DESCRIPTION
After an item is chosen, we should clear the selected item in the list view. The implementation is a little weird. I noticed that code was pretty old that I was editing :). This fixes a bug where the same item will be selected multiple times when it shouldn't be.
