### PR TITLE
splitview: add an option to forceResize all panels

### DIFF
--- a/src/components/split/splitview.coffee
+++ b/src/components/split/splitview.coffee
@@ -305,7 +305,7 @@ module.exports = class KDSplitView extends KDView
     @showPanel index
     @emit 'PanelSetToNormal', panel
 
-  resizePanel:(value = 0, index = 0, callback = noop)->
+  resizePanel:(value = 0, index = 0, callback = noop, forceResize = no)->
 
     return  unless @sizes[1]?
     return  if @beingResized
@@ -317,7 +317,7 @@ module.exports = class KDSplitView extends KDView
     askedPanel    = @panels[index]
     affectedPanel = @panels[(index + 1) % 2]
 
-    if askedPanel._getSize() is value
+    if askedPanel._getSize() is value and not forceResize
       @_resizeDidStop()
       callback()
       return


### PR DESCRIPTION
This PR solves the following problem via adding another parameter called `forceResize` to the `_calculateSize` method.
- When left/top panel reaches the required size it returns early even though the other panel still needs resizing. This gives another option to discard that situation and resize the panels no matter what.

I know this is kind of a dirty solution, but I am taking notes of these kind of situations, and will try to address them in a proper way, hopefully, when we rewrite/refactor these components. Also, this kind of modification gives us a way to solve those kind of problems without breaking backwards compatibility.
