### PR TITLE
Enable/disable console output

### DIFF
--- a/lib/core/kd.coffee
+++ b/lib/core/kd.coffee
@@ -59,12 +59,12 @@ module.exports =
     inst.on 'KDObjectWillBeDestroyed', => delete instancesToBeTested[key]
 
   noop: ->
-  log: console.log.bind console
-  warn: console.warn.bind console
-  error: console.error.bind console
-  info: console.info.bind console
-  time: console.time.bind console
-  timeEnd: console.timeEnd.bind console
+  log: -> console.log.apply console, arguments
+  warn: -> console.warn.apply console, arguments
+  error: -> console.error.apply console, arguments
+  info: -> console.info.apply console, arguments
+  time: -> console.time.apply console, arguments
+  timeEnd: -> console.timeEnd.apply console, arguments
 
   debugStates: debugStates
   instances: instances

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kd.js",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "description": "a collection of ui widgets and other nice things",
   "main": "build/lib/index.js",
   "scripts": {


### PR DESCRIPTION
@sinan, can you please review this fix?
The reason why I made these changes is that `kd` keeps references to `console` methods and use those references for `kd.log`, `kd.warn`, `kd.error` etc. This logic makes useless any try to overwrite `console` methods to disable logging - https://github.com/koding/koding/blob/master/client/app/lib/util/disableLogs.coffee#L34
Wrapping `console` calls with functions helps to solve this problem