### PR TITLE
router: fix for popstate event on page load in Safari

### DIFF
--- a/lib/core/router.coffee
+++ b/lib/core/router.coffee
@@ -68,14 +68,15 @@ module.exports = class KDRouter extends KDObject
   startListening:->
     return no  if @isListening # make this action idempotent
     @isListening = yes
-    # we need to add a listener to the window's popstate event:
-    window.addEventListener 'popstate', @bound "popState"
 
     if isWindowLoaded()
       @blockPopstateIfWindowLoaded = no
     else
       @blockPopstateIfWindowLoaded = yes
       window.addEventListener 'load', @bound 'handleWindowLoad'
+
+    # we need to add a listener to the window's popstate event:
+    window.addEventListener 'popstate', @bound "popState"
 
     return yes
 

--- a/lib/core/router.coffee
+++ b/lib/core/router.coffee
@@ -58,7 +58,7 @@ module.exports = class KDRouter extends KDObject
 
   startListening: do ->
 
-    readyStateBinded = no
+    readyStateBound = no
 
     ->
       return no  if @isListening # make this action idempotent
@@ -66,9 +66,9 @@ module.exports = class KDRouter extends KDObject
       # Safari fires extra popstate event right after window is loaded
       # this is to avoid this inconsistent initial firing
       unless document.readyState is 'complete'
-        return  if readyStateBinded
+        return  if readyStateBound
 
-        readyStateBinded = yes
+        readyStateBound = yes
         return document.addEventListener 'readystatechange', =>
           KD.utils.defer => @startListening()  if document.readyState is 'complete'
 

--- a/lib/core/router.coffee
+++ b/lib/core/router.coffee
@@ -65,7 +65,9 @@ module.exports = class KDRouter extends KDObject
 
       # Safari fires extra popstate event right after window is loaded
       # this is to avoid this inconsistent initial firing
-      if document.readyState isnt 'complete' and not readyStateBinded
+      unless document.readyState is 'complete'
+        return  if readyStateBinded
+
         readyStateBinded = yes
         return document.addEventListener 'readystatechange', =>
           KD.utils.defer => @startListening()  if document.readyState is 'complete'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kd.js",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "a collection of ui widgets and other nice things",
   "main": "build/lib/index.js",
   "scripts": {


### PR DESCRIPTION
@sinan, can you please review this fix?
Currently we have a problem that Safari fires `popstate` event after the page is loaded. In some cases it causes double rendering since router handler is called one more time.
This issue is mentioned on MDN (https://developer.mozilla.org/ru/docs/Web/Events/popstate):
```
Browsers tend to handle the popstate event differently on page load. Chrome (prior to v34) and Safari always emit a popstate event on page load, but Firefox doesn't.
```
The idea of this fix is taken from here - http://stackoverflow.com/a/18126524. The most important thing here is that Safari fires `popstate` right after window is loaded. So we catch this moment and skip `popstate` handling. Note that if `popstate` event is triggered before page is loaded (for example, page is loading slowly and user clicks `Back` button) or after that, behavior isn't changed.

/cc @gokmen 