### PR TITLE
Use new timeago.js library

### DIFF
--- a/lib/components/time/timeagoview.coffee
+++ b/lib/components/time/timeagoview.coffee
@@ -1,7 +1,7 @@
 $ = require 'jquery'
 KD = require '../../core/kd'
 KDView = require '../../core/view'
-timeago = require 'timeago'
+timeago = new require 'timeago'
 
 module.exports = class KDTimeAgoView extends KDView
 
@@ -15,11 +15,11 @@ module.exports = class KDTimeAgoView extends KDView
 
     super options, data
 
-    KDTimeAgoView.on "OneMinutePassed", => @updatePartial timeago @getData()
+    KDTimeAgoView.on "OneMinutePassed", => @updatePartial timeago.format @getData()
 
   setData: ->
     super
-    @updatePartial timeago @getData()  if @parent
+    @updatePartial timeago.format @getData()  if @parent
 
   viewAppended: ->
-    @setPartial timeago @getData()
+    @setPartial timeago.format @getData()

--- a/lib/components/time/timeagoview.coffee
+++ b/lib/components/time/timeagoview.coffee
@@ -1,7 +1,7 @@
 $ = require 'jquery'
 KD = require '../../core/kd'
 KDView = require '../../core/view'
-timeago = new require 'timeago'
+timeago = new require 'timeago.js'
 
 module.exports = class KDTimeAgoView extends KDView
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "kd-shim-canvas-loader": "^0.9.2",
     "kd-shim-mutation-summary": "^0.1.0",
     "lodash": "^4.16.4",
-    "timeago": "^1.5.3"
+    "timeago.js": "^2.0.3"
   },
   "devDependencies": {
     "browserify": "^13.1.0",


### PR DESCRIPTION
Replace the heavy jQuery.timeago plugin with a smaller library named [timeago.js](https://github.com/hustcc/timeago.js).

This library is ~2KB, has no dependencies and includes several built-in locales. It also updates the timestamp on the page in realtime.